### PR TITLE
"distributed" multiplication in deg2hms to avoid rounding error due to floating point rounding errors.

### DIFF
--- a/src/spatial.rs
+++ b/src/spatial.rs
@@ -78,7 +78,7 @@ pub fn deg2hms(deg: f64) -> String {
 
     let h = deg * 12.0 / 180.0;
     let hours = h.floor() as i32;
-    let m = (h - hours as f64) * 60.0;
+    let m = h * 60.0 - hours as f64 * 60.0;
     let minutes = m.floor() as i32;
     let seconds = (m - minutes as f64) * 60.0;
     let hms = format!("{:02.0}:{:02.0}:{:07.4}", hours, minutes, seconds);


### PR DESCRIPTION
I've just edited the one line in the function, it could be that the deg2dms function has the same issue.
Minimal working example is now:
```rust
use flare::spatial;
fn main() {
    let hms = spatial::deg2hms(180.5);
    println!("{}", hms);
    assert_eq!(hms, "12:02:00.0000");
```